### PR TITLE
docs: use correct package name for circup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install floppy
+    circup install adafruit_floppy
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
updates the readme so the circup command installs the package rather than erroring out because of an invalid package name